### PR TITLE
Add JVM sample application

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -2,20 +2,21 @@
 
 A minimal JVM application demonstrating how to play audio with the `basic-sound` library.
 
+This project uses a Gradle [composite build](https://docs.gradle.org/current/userguide/composite_builds.html) to substitute the published dependency with the local source code from the parent directory. Any changes you make to the library are picked up automatically.
+
 ## Running
 
-1. Build the library jar:
-   ```
-   ./gradlew :basic-sound:jvmJar
-   ```
-2. Run the sample, providing an audio file path or URL. If omitted, you'll be prompted at runtime:
-   ```
-   ./gradlew -p sample run --args="<audio-path-or-url>"
-   ```
-   or
-   ```
-   ./gradlew -p sample run
-   Enter audio resource (file path or URL): /path/to/audio.mp3
-   ```
+Run the sample, optionally providing an audio file path or URL. If omitted, you'll be prompted at runtime:
+
+```
+./gradlew -p sample run --args="<audio-path-or-url>"
+```
+
+or
+
+```
+./gradlew -p sample run
+Enter audio resource (file path or URL): /path/to/audio.mp3
+```
 
 The program plays the sound and waits for you to press **ENTER** before releasing resources.

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,0 +1,21 @@
+# Basic Sound Sample
+
+A minimal JVM application demonstrating how to play audio with the `basic-sound` library.
+
+## Running
+
+1. Build the library jar:
+   ```
+   ./gradlew :basic-sound:jvmJar
+   ```
+2. Run the sample, providing an audio file path or URL. If omitted, you'll be prompted at runtime:
+   ```
+   ./gradlew -p sample run --args="<audio-path-or-url>"
+   ```
+   or
+   ```
+   ./gradlew -p sample run
+   Enter audio resource (file path or URL): /path/to/audio.mp3
+   ```
+
+The program plays the sound and waits for you to press **ENTER** before releasing resources.

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation(fileTree("../basic-sound/build/libs") { include("basic-sound-jvm-*.jar") })
+    implementation("app.lexilabs.basic:basic-sound:0.2.6-beta01")
 }
 
 application {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm") version "2.1.21"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(fileTree("../basic-sound/build/libs") { include("basic-sound-jvm-*.jar") })
+}
+
+application {
+    mainClass.set("MainKt")
+}

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -6,3 +6,9 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+includeBuild("..") {
+    dependencySubstitution {
+        substitute(module("app.lexilabs.basic:basic-sound")).using(project(":basic-sound"))
+    }
+}

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -1,0 +1,8 @@
+rootProject.name = "basic-sound-sample"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}

--- a/sample/src/main/kotlin/Main.kt
+++ b/sample/src/main/kotlin/Main.kt
@@ -1,0 +1,15 @@
+import app.lexilabs.basic.sound.Audio
+
+fun main(args: Array<String>) {
+    val resource = if (args.isNotEmpty()) {
+        args[0]
+    } else {
+        print("Enter audio resource (file path or URL): ")
+        readln().trim()
+    }
+
+    val audio = Audio(resource, autoPlay = true)
+    println("Playing '$resource'. Press ENTER to stop.")
+    readln()
+    audio.release()
+}

--- a/sample/src/main/kotlin/Main.kt
+++ b/sample/src/main/kotlin/Main.kt
@@ -1,5 +1,7 @@
 import app.lexilabs.basic.sound.Audio
+import app.lexilabs.basic.sound.ExperimentalBasicSound
 
+@OptIn(ExperimentalBasicSound::class)
 fun main(args: Array<String>) {
     val resource = if (args.isNotEmpty()) {
         args[0]


### PR DESCRIPTION
## Summary
- add standalone sample project demonstrating Audio playback

## Testing
- `./gradlew :basic-sound:jvmJar` *(fails: Could not resolve dependencies, HTTP 403)*
- `./gradlew -p sample build` *(fails: plugin org.jetbrains.kotlin.jvm 2.1.21 not found)*
- `./gradlew build` *(fails: Android SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b29020a02c83329a4ee73e9d9b0931