### PR TITLE
Use URL for HTTP audio loading

### DIFF
--- a/basic-sound/src/jvmMain/kotlin/app/lexilabs/basic/sound/Audio.kt
+++ b/basic-sound/src/jvmMain/kotlin/app/lexilabs/basic/sound/Audio.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
+import java.net.URL
 import javax.sound.sampled.AudioSystem
 import javax.sound.sampled.Clip
-import kotlin.io.path.Path
 
 @ExperimentalBasicSound
 public actual class Audio actual constructor(): AudioBuilder {
@@ -38,8 +38,8 @@ public actual class Audio actual constructor(): AudioBuilder {
             _audioState.value = AudioState.LOADING
 
             val stream = if (resource.substring(0, 4) == "http") {
-                AudioSystem.getAudioInputStream(Path(resource).toUri().toURL())
-                    ?: throw IllegalStateException("load:The URL provided was invalid or failed to load")
+                AudioSystem.getAudioInputStream(URL(resource))
+                    ?: throw IllegalStateException("load:The resource URL was invalid or failed to load")
             } else {
                 AudioSystem.getAudioInputStream(File(resource).absoluteFile)
                     ?: throw IllegalStateException("load:The path provided was invalid")


### PR DESCRIPTION
## Summary
- load HTTP audio streams using `URL(resource)` instead of `Path`
- import `java.net.URL` and update error message

## Testing
- `./gradlew :basic-sound:jvmTest` *(fails: Could not resolve dependencies, received 403 from Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68b203e1e9a08332823015d606ca9b3a